### PR TITLE
Update X509Certificate2Signature.cs

### DIFF
--- a/iText/iTextSharp/text/pdf/security/X509Certificate2Signature.cs
+++ b/iText/iTextSharp/text/pdf/security/X509Certificate2Signature.cs
@@ -41,8 +41,11 @@ namespace iTextSharp.text.pdf.security {
 
         public virtual byte[] Sign(byte[] message) {
             if (certificate.PrivateKey is RSACryptoServiceProvider) {
-                RSACryptoServiceProvider rsa = (RSACryptoServiceProvider)certificate.PrivateKey;
-                //TODO jbonilla-No siempre funciona con SHA-256
+                // Force rsa all PrivateKey properties 
+                //Including  Private Parameters  
+                //Instead of cast  that does not always work
+                RSACryptoServiceProvider rsa = new   RSACryptoServiceProvider() ;
+                rsa.FromXmlString(certificate.PrivateKey.ToXmlString(true)) ;      
                 return rsa.SignData(message, hashAlgorithm);
             }
             else {


### PR DESCRIPTION
The previous version was :
And author wrote :   TODO jbonilla-No siempre funciona con SHA-256   

  public virtual byte[] Sign(byte[] message) {
            if (certificate.PrivateKey is RSACryptoServiceProvider) {
                RSACryptoServiceProvider rsa = (RSACryptoServiceProvider)certificate.PrivateKey;
                // TODO jbonilla-No siempre funciona con SHA-256   
                return rsa.SignData(message, hashAlgorithm);
            }
            else {
                DSACryptoServiceProvider dsa = (DSACryptoServiceProvider)certificate.PrivateKey;
                return dsa.SignData(message);
            }
        }

I change cast with : 
This bypass microsoft   and force pass  all private key parameter in rsa   
 RSACryptoServiceProvider rsa = new   RSACryptoServiceProvider() ;
 rsa.FromXmlString(certificate.PrivateKey.ToXmlString( true )) ;              
