### PR TITLE
Fixed DSS License: it was LGPL 2.1, not gpl 2.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 DSS
 ===
-http://www.gnu.org/licenses/gpl-2.0.html
+http://www.gnu.org/licenses/lgpl-2.1.html
 
 iTextSharp
 ==========


### PR DESCRIPTION
This is actually mentioned in all file license headers.

Link to the actual original license in the official DSS repository:
https://github.com/esig/dss/blob/master/LICENSE